### PR TITLE
Mod item pricing fix and Flib 0.8 compatibility

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -27,6 +27,8 @@ function configure_settings()
 		["steam"] = settings.global["BM2-steam"].value,
 	}
 
+	unknown_price_reason_logging = settings.global["BM2-unknown_price_reason_logging"]
+
 	recipe_depth_maximum = settings.global["BM2-recipe_depth_maximum"].value -- the maximum depth the recipe search can go
 	only_items_researched = settings.global["BM2-only_items_researched"].value -- if only want researched items enabled or not
 	tax_enabled = settings.global["BM2-enable_tax"].value -- if taxes enabled or not

--- a/control.lua
+++ b/control.lua
@@ -825,7 +825,7 @@ local function compute_item_cost(item_name, loops, recipes_used)
 	-- iterate through ingredients and make sure they have a set cost
 	for _, ingredient in pairs(recipe.ingredients) do
 		if global.prices[ingredient.name] ~= nil then -- do we know the price already?
-			ingredient_cost = global.prices[ingredient.name].overall
+			-- we can move on to the next ingredient
 			
 		elseif global.item_recipes[ingredient.name] ~= nil and global.item_recipes[ingredient.name].recipe ~= nil then -- if not and we have a recipe for the ingredient then loop through and calculate it based on ingredients
 			compute_item_cost(ingredient.name, loops, recipes_used)
@@ -867,9 +867,9 @@ local function compute_item_cost(item_name, loops, recipes_used)
 	local energy_cost = recipe.energy * energy_cost
 
 	-- enter cost of ingredient
-	if ingredient_amount == 0 then
+	if product_amount == 0 then
 		-- sometimes, probability can be 0, leading to total amount = 0
-		item_cost_unknown(item_name, "ingredient_amount == 0")
+		item_cost_unknown(item_name, "product_amount == 0")
 	else
 		local tech_total = math.floor(tech_cost)
 		local ingrs_total = math.floor(ingredients_cost / product_amount+0.5)

--- a/control.lua
+++ b/control.lua
@@ -835,7 +835,7 @@ local function compute_item_cost(item_name, loops, recipes_used)
 		end
 	end
 
-	-- okay we now know that the price of the ingrs are in the prices table, so now we can just add em up
+	-- okay we now know that the price of the ingredients are in the prices table, so now we can just add em up
 	local ingredients_cost = 0
 	for _, ingredient in pairs(recipe.ingredients) do
 		if global.prices[ingredient.name] == nil then compute_item_cost(ingredient.name, loops, recipes_used) end

--- a/control.lua
+++ b/control.lua
@@ -1858,8 +1858,8 @@ end
 --------------------------------------------------------------------------------------
 local function on_init()
 	-- called once, the first time the mod is loaded on a game (new or existing game)
-	gui.init()
-	gui.build_lookup_tables()
+	---gui.init()
+	---gui.build_lookup_tables()
 	init_globals()
 	init_forces()
 	init_players()
@@ -1867,10 +1867,10 @@ end
 
 script.on_init(on_init)
 
-local function on_load()
-	gui.build_lookup_tables()
-end
-script.on_load(on_load)
+---local function on_load()
+---	gui.build_lookup_tables()
+---end
+---script.on_load(on_load)
 
 --------------------------------------------------------------------------------------
 local function on_configuration_changed(data)
@@ -1884,8 +1884,8 @@ local function on_configuration_changed(data)
 		init_tax_rates()
 		
 		local changes = data.mod_changes[debug_mod_name]
-		gui.init()
-		gui.check_filter_validity()
+		---gui.init()
+		---gui.check_filter_validity()
 		
 		close_guis()
 

--- a/control.lua
+++ b/control.lua
@@ -788,9 +788,8 @@ local function compute_recipe_purity(recipe_name, item_name)
 end
 
 local function compute_item_cost(item_name, loops, recipes_used)
-	if loops == nil then loops = 0 end -- my lazy solution to avoid endless recursion
-	if recipes_used == nil then recipes_used = {} end -- same as above
-	loops = loops + 1
+	loops = (loops or 0) + 1
+	recipes_used = recipes_used or {}
 
 	-- if this is an uncraftable item then we just assume its a raw/unknown
 	if global.item_recipes[item_name] == nil or loops > recipe_depth_maximum then

--- a/control.lua
+++ b/control.lua
@@ -764,7 +764,7 @@ local function compute_recipe_purity(recipe_name, item_name)
 	local ingredient_amount = 0 -- the stuff we are actually trying to solve for
 
 	table.for_each(recipe.products, function(product)
-		-- here we catogorize each of the recipes products into product or other
+		-- here we categorize each of the recipes products into product or other
 		if product.name == item_name then
 			if product.amount ~= nil then
 				ingredient_amount = ingredient_amount + product.amount
@@ -803,7 +803,7 @@ local function compute_item_cost(item_name, loops, recipes_used)
 		global.prices[item_name] = {overall = unknown_price, tech = 0, ingrs = 0, energy = 0} return global.prices[item_name] end end
 	recipes_used[#recipes_used+1] = recipe_name
 
-	-- iterate thru ingredients and make sure they have a set cost
+	-- iterate through ingredients and make sure they have a set cost
 	for _, ingredient in pairs(recipe.ingredients) do
 		if global.prices[ingredient.name] ~= nil then -- do we know the price already?
 			ingredient_cost = global.prices[ingredient.name].overall
@@ -821,7 +821,7 @@ local function compute_item_cost(item_name, loops, recipes_used)
 		end
 	end
 
-	-- okay we now know that the price of the igrs are in the prices table, so now we can just add em up
+	-- okay we now know that the price of the ingrs are in the prices table, so now we can just add em up
 	local ingredients_cost = 0
 	for _, ingredient in pairs(recipe.ingredients) do
 		if global.prices[ingredient.name] == nil then compute_item_cost(ingredient.name, loops, recipes_used) end
@@ -884,7 +884,7 @@ local function update_objects_prices()
 	for _, recipe in pairs(game.forces.player.recipes) do
 		for _, product in pairs(recipe.products) do
 
-			if game.forces.player.recipes[product.name] ~= nil then -- if we can find a direct recipe match for the item then we dont need to do fancy match
+			if game.forces.player.recipes[product.name] ~= nil then -- if we can find a direct recipe match for the item then we don't need to do fancy match
 				item_recipe = {name = product.name, recipe = product.name}
 			else -- recipe matching, the filters avoid recipes that cause issues for the cost computer
 				item_recipe = global.item_recipes[product.name] or {name = product.name, recipe = nil}
@@ -895,25 +895,25 @@ local function update_objects_prices()
 					
 					local new_purity = compute_recipe_purity(recipe.name, product.name)
 
-					-- recipe filters here, the recipes we dont want
+					-- recipe filters here, the recipes we don't want
 
 					-- such as fluid barreling recipes
 					local isBarrel = false
 					if string.match(recipe.name, "barrel") and not string.match(product.name, "barrel") then
 						isBarrel = true end
 
-					-- or recipes with catylists
-					local hasCatylist = false
+					-- or recipes with catalysts
+					local hasCatalyst = false
 					table.for_each(game.forces.player.recipes[recipe.name].products, function(product)
 						-- if the recipe just straight up tells us
-						if product.catalyst_amount ~= nil and product.catalyst_amount > 0 then hasCatylist = true
+						if product.catalyst_amount ~= nil and product.catalyst_amount > 0 then hasCatalyst = true
 						-- otherwise check for name matches
-						else table.for_each(game.forces.player.recipes[recipe.name].ingredients, function(ingr) if ingr.name == product.name then hasCatylist = true end end)
+						else table.for_each(game.forces.player.recipes[recipe.name].ingredients, function(ingr) if ingr.name == product.name then hasCatalyst = true end end)
 						end
 					end)
 
-					if new_purity > old_purity and isBarrel == false and hasCatylist == false then item_recipe.recipe = recipe.name end -- our new king passed our filters!
-				else item_recipe.recipe = recipe.name end -- if there is no prexisting recipe our new one is king
+					if new_purity > old_purity and isBarrel == false and hasCatalyst == false then item_recipe.recipe = recipe.name end -- our new king passed our filters!
+				else item_recipe.recipe = recipe.name end -- if there is no preexisting recipe our new one is king
 			end
 			
 			global.item_recipes[product.name] = item_recipe
@@ -933,7 +933,7 @@ local function update_objects_prices()
 		if price.overall == nil then price.overall = unknown_price end
 		if price.overall == math.huge then price.overall = unknown_price end
 
-		-- actuall dynamic stuff
+		-- actually dynamic stuff
 		if old_price then
 			price.dynamic = old_price.dynamic or 1
 			price.previous = old_price.previous or price.overall
@@ -1117,7 +1117,7 @@ local function list_groups()
 	debug_print("list_groups")
 	
 	for name, group in pairs(global.groups) do
-		debug_print("group:", name, " childs=", #group.group.subgroups)
+		debug_print("group:", name, " children=", #group.group.subgroups)
 		for _, subgroup in pairs(group.group.subgroups) do
 			debug_print("-> subgroup:", subgroup.name)
 		end
@@ -1208,7 +1208,7 @@ local function init_trader( trader, level )
 	trader.orders_tot = 0 -- total of the purchase list, without taxes
 	trader.orders = {} -- purchase orders, list of {name, count}
 	trader.sold_name = nil -- name of the last sold item
-	-- trader.price = nil -- price of the main object sold (1 item, fuild or energy)
+	-- trader.price = nil -- price of the main object sold (1 item, fluid or energy)
 	
 	trader.editer = nil -- player who is currently editing
 	

--- a/control.lua
+++ b/control.lua
@@ -793,14 +793,21 @@ local function compute_item_cost(item_name, loops, recipes_used)
 	loops = loops + 1
 
 	-- if this is an uncraftable item then we just assume its a raw/unknown
-	if global.item_recipes[item_name] == nil or loops > recipe_depth_maximum then global.prices[item_name] = {overall = unknown_price, tech = 0, ingrs = 0, energy = 0} return global.prices[item_name] end
+	if global.item_recipes[item_name] == nil or loops > recipe_depth_maximum then
+		global.prices[item_name] = {overall = unknown_price, tech = 0, ingrs = 0, energy = 0}
+		return global.prices[item_name]
+	end
 	
 	-- grab the item's recipe
 	local recipe_name = global.item_recipes[item_name].recipe
 	local recipe = game.forces.player.recipes[recipe_name]
 
-	for _, recipe_used in pairs(recipes_used) do if recipe_used == recipe_name then 
-		global.prices[item_name] = {overall = unknown_price, tech = 0, ingrs = 0, energy = 0} return global.prices[item_name] end end
+	for _, recipe_used in pairs(recipes_used) do
+		if recipe_used == recipe_name then
+			global.prices[item_name] = {overall = unknown_price, tech = 0, ingrs = 0, energy = 0}
+			return global.prices[item_name]
+		end
+	end
 	recipes_used[#recipes_used+1] = recipe_name
 
 	-- iterate through ingredients and make sure they have a set cost

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "BlackMarket2",
-	"version": "2.0.6",
+	"version": "2.0.7",
 	"title": "Black Market 2",
 	"author": "djmango",
 	"description": "Sell and buy items/fluids/energy on the universal black market using trading chests/tanks/accumulators, choosing the frequency of exchanges and related fees. You can now sell your overproduction and buy things that you don't want to craft by yourself. You can also use these trading units as a paying shipment system.",
@@ -9,7 +9,7 @@
 	"factorio_version":"1.1",
 	"dependencies": [
 		"base >= 1.0.0",
-		"flib = 0.7.0",
+		"flib >= 0.8.0",
 		"! deadlock-beltboxes-loaders"
 	]
 }

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -234,6 +234,7 @@ BM2-tax_start=Tax start
 BM2-tax_growth=Tax growth
 BM2-tax_immediate=Tax immediate
 BM2-recipe_depth_maximum=Recipe depth maximum
+BM2-unknown_price_reason_logging=Price Debugging
 
 [mod-setting-description]
 BM2-dynamic_prices=If this is turned off then the prices remain the same no matter how much you sell or buy
@@ -271,3 +272,4 @@ BM2-tax_start=Starting fee in % for one action per day
 BM2-tax_growth=Exponential growth with frequency/day : fee = tax_start * (freq ^ tax_growth)
 BM2-tax_immediate=% Fee for immediate action
 BM2-recipe_depth_maximum=Recipe the maximum 'depth' that BM2 will look into for a recipe, to find its cost.
+BM2-unknown_price_reason_logging=Writes a log of items that are priced as unknown, and the reason for such

--- a/settings.lua
+++ b/settings.lua
@@ -287,5 +287,12 @@ data:extend({
         minimum_value = 1,
         default_value = 10,
         order = "ga"
+    },
+    {
+        type = "bool-setting",
+        name = "BM2-unknown_price_reason_logging",
+        setting_type = "runtime-global",
+        default_value = false,
+        order = "gb"
     }
 })

--- a/symlink.sh
+++ b/symlink.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-ln -sf ~/github/BlackMarket2 ~/.factorio/mods/BlackMarket2_2.0.5
+ln -sf "$(readlink -f .)" ~/.factorio/mods/BlackMarket2_2.0.7


### PR DESCRIPTION
Hi,

This is my first public PR, so please feel free to let me know what I can do better with regards to contributing.

The current release gets around problems caused by recent changes to Flib by listing dependency on a prior version, but Factorio (and presumably some of the other mods I'm using) don't want to downgrade to that prior version. There seems to be a bug causing most angel-bob items to default to the price for unknown items, as well.

The reason why Flib 0.8+ causes BM2 to crash is because it has depreciated a few of its functions (Flib seems to just automatically take care of what those functions accomplished without needing "users" to manually call them). To that end, those calls have been commented out and the flib dependency is now `"flib >= 0.8.0"`.

For mod item pricing, I added a function that allows for logging of the reason for any item's price getting set to `unknown_price` and an accompanying setting (off by default) so that it isn't stuck always logging. The cause for lots of items getting set to `unknown_price` seems to have been a small typo at the end of price calculation.

I took the liberty of making some spelling changes in some comments and `debug_print` statements (to one local variable as well) and reformatting some one line for/if blocks.

I incremented the minor version number by 1 (`"version": "2.0.7"`).

Finally `symlink.sh` creates a link from wherever it is being run to the mods folder, in case the current user organizes their files a bit differently.