### PR TITLE
wanna fix a conflict

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -2197,7 +2197,22 @@ local function on_tick(event)
 						end
 						
 						local force_mem = global.force_mem[player.force.name]
-						local prefix = string.sub(opened.name,1,15)
+						local prefix
+
+						-- try-catch add start
+						local success_tc, result_tc = pcall(function()
+							-- get "name"
+							prefix = string.sub(opened.name,1,15)
+						end)
+
+						if success_tc then
+							-- no error
+							print("success")
+						else
+							-- with error
+							prefix = "opened.name,1,15"
+						end
+						-- try-catch add end
 						
 						if prefix == "trader-chst-sel" or prefix == "trader-tank-sel" or prefix == "trader-accu-sel" then
 							build_menu_objects(player,false)


### PR DESCRIPTION
Hello, I've identified a conflict between the BlackMarket2 and Py AlienLife mods, and I attempted to resolve it. The issue arose because a UI element in Py AlienLife didn't have the key "name," but BlackMarket2 was attempting to read "name." This caused the game to crash when I tried to open this UI. The traceback points to control.lua in BlackMarket2 at lines 2200 and 2156. To address this, I added a try-catch block around the reading of "name," and fortunately, I was able to compile it successfully.

I apologize once again for not being able to locate the specific changes made by Py AlienLife, which led to modifications in your mod.

I greatly appreciate the mod you've created; it has provided me with a lot of enjoyment in the game.

PS: My English isn't great either, so I'm using machine translation. I apologize for any errors.
PS2: I'm also not familiar with Lua, so my coding skills are likely not very proficient.