### PR TITLE
Fix migration of saves with sold quality items

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -37,6 +37,10 @@ table.sort(quality_list, function(a, b) return a.level <= b.level end)
 local vanilla_quality_multipliers = {1, 2.1, 4.8, 10.5, 35}
 
 local function get_quality_multiplier(level) -- level is 1 indexed (1 = normal, 2 = uncommon, ...)
+	if type(level) == "string" then
+		level = quality_lookup_by_name[level].level + 1
+	end
+
 	if level <= 5 then
 		return vanilla_quality_multipliers[level]
 	else


### PR DESCRIPTION
Fixes this

![image](https://github.com/user-attachments/assets/0efc3b00-949e-44bb-8ac4-0a73cf5fa546)

https://github.com/djmango/BlackMarket2/blob/5511ae640658346468294128336d4db246b65918/control.lua#L469-L471

Apparently sold_quality was set to string before which is not great, but oh well