### PR TITLE
Fixed new buy order issue when mixed with Py as mentioned in issue #65

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -2776,7 +2776,7 @@ local function on_gui_click(event)
 		
 		if trader.type == trader_type.item then
 			if #trader.orders < 99 then
-				table.insert(trader.orders,1,{name="coal", count=0, price=storage.prices.coal.current, quality=1})
+				table.insert(trader.orders,1,{name="ucoin", count=0, price=storage.prices.ucoin.current, quality=1})
 				update_menu_trader(player,player_mem,true)
 			end
 		end


### PR DESCRIPTION
Fixed the issue reported by Sageboba.
https://github.com/djmango/BlackMarket2/issues/65

The solution that worked was just changing it from asking for coal, when it would be better to just ask for ucoin as default item when creating a new buy order