### PR TITLE
feat: implement configurable GUI scaling for icons and windows

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -421,7 +421,8 @@ local function build_menu_trader( player, player_mem, open_or_close )
 				
 			gui2 = gui1.add({type = "flow", name = "flw_blkmkt_trader_orders", direction = "horizontal", style = "horizontal_flow_blkmkt_style"})
 			gui2 = gui2.add({type = "scroll-pane", name = "scr_blkmkt_trader_orders", vertical_scroll_policy = "auto"})
-			gui2.style.maximal_height = 150
+			local gui_scale = settings.global["BM2-gui_scale"].value
+			gui2.style.maximal_height = math.floor(150 * gui_scale)
 			player_mem.scr_blkmkt_trader_orders = gui2
 		end
 	end
@@ -593,7 +594,8 @@ local function build_menu_objects(player, open_or_close, ask_sel)
 		-- main_window = main_window.add({type = "empty-widget", ignored_by_interaction="true", name = "main_window_drag_handle", style = "flib_titlebar_drag_handle"})
 		main_window = main_window.add({type = "flow", name = "flw_blkmkt_itml", direction = "vertical", style = "vertical_flow_blkmkt_style"})
 		-- main_window.style.minimal_height = 500
-		main_window.style.minimal_width = 380
+		local gui_scale = settings.global["BM2-gui_scale"].value
+		main_window.style.minimal_width = math.floor(380 * gui_scale)
 		
 		item_table_holder = main_window.add({type = "scroll-pane", name = "scr_blkmkt_itml", vertical_scroll_policy = "auto"}) -- , style = "scroll_pane_blkmkt_style"
 		-- item_table_holder.style.maximal_height = 450
@@ -615,7 +617,7 @@ local function build_menu_objects(player, open_or_close, ask_sel)
 		end
 		
 		item_table = item_table_holder.add({type = "scroll-pane", name = "flib_naked_scroll_pane_no_padding", vertical_scroll_policy = "auto"})
-		item_table.style.maximal_height = 200
+		item_table.style.maximal_height = math.floor(200 * gui_scale)
 		item_table = item_table.add({type = "table", name = "tab_blkmkt_itml2", column_count = 10, style = "table_blkmkt_style"})
 		
 		local group = storage.groups[player_mem.group_sel_name].group

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -1,6 +1,9 @@
 require("utils")
 require("config")
 
+-- GUI scale multiplier from mod settings
+local gui_scale = settings.global["BM2-gui_scale"].value
+
 data:extend(
 	{
 		----------------------------------------------------------------------------------
@@ -8,7 +11,7 @@ data:extend(
 			type = "item-group",
 			name = "black-market-group",
 			icon = "__BlackMarket2__/graphics/black-market-group.png",
-			icon_size = 64,
+			icon_size = math.floor(64 * gui_scale),
 			inventory_order = "n",
 			order = "n"
 		},
@@ -41,7 +44,7 @@ data:extend(
 			type = "item",
 			name = "ucoin",
 			icon = "__BlackMarket2__/graphics/ucoin.png",
-			icon_size = 32,
+			icon_size = math.floor(32 * gui_scale),
 			subgroup = "black-market-general",
 			order = "y",
 			stack_size = 1000000
@@ -51,7 +54,7 @@ data:extend(
 			type = "technology",
 			name = "black-market-item",
 			icon = "__BlackMarket2__/graphics/black-market-item.png",
-			icon_size = 128,
+			icon_size = math.floor(128 * gui_scale),
 			enabled = true,
 			unit = {
 				count = 75,
@@ -74,7 +77,7 @@ data:extend(
 			type = "technology",
 			name = "black-market-fluid",
 			icon = "__BlackMarket2__/graphics/black-market-fluid.png",
-			icon_size = 128,
+			icon_size = math.floor(128 * gui_scale),
 			enabled = true,
 			prerequisites = { "black-market-item", "fluid-handling" },
 			unit = {
@@ -103,7 +106,7 @@ data:extend(
 			type = "technology",
 			name = "black-market-energy",
 			icon = "__BlackMarket2__/graphics/black-market-energy.png",
-			icon_size = 128,
+			icon_size = math.floor(128 * gui_scale),
 			enabled = true,
 			prerequisites = { "black-market-item", "electric-energy-accumulators" },
 			unit = {
@@ -132,7 +135,7 @@ data:extend(
 			type = "technology",
 			name = "black-market-mk2",
 			icon = "__BlackMarket2__/graphics/black-market-mk.png",
-			icon_size = 128,
+			icon_size = math.floor(128 * gui_scale),
 			enabled = true,
 			upgrade = true,
 			prerequisites = {"steel-processing", "black-market-item", "black-market-fluid", "black-market-energy" },
@@ -155,7 +158,7 @@ data:extend(
 			type = "technology",
 			name = "black-market-mk3",
 			icon = "__BlackMarket2__/graphics/black-market-mk.png",
-			icon_size = 128,
+			icon_size = math.floor(128 * gui_scale),
 			enabled = true,
 			upgrade = true,
 			prerequisites = { "black-market-mk2" },
@@ -178,7 +181,7 @@ data:extend(
 			type = "technology",
 			name = "black-market-mk4",
 			icon = "__BlackMarket2__/graphics/black-market-mk.png",
-			icon_size = 128,
+			icon_size = math.floor(128 * gui_scale),
 			enabled = true,
 			upgrade = true,
 			prerequisites = { "black-market-mk3" },
@@ -250,7 +253,7 @@ local function add_chests(level)
 				type = "item",
 				name = name_sell,
 				icon = "__BlackMarket2__/graphics/trading-chest-sell-icon.png",
-				icon_size = 32,
+				icon_size = math.floor(32 * gui_scale),
 				subgroup = "black-market-chests",
 				order = level .. "a",
 				place_result = name_sell,
@@ -290,7 +293,7 @@ local function add_chests(level)
 				type = "item",
 				name = name_buy,
 				icon = "__BlackMarket2__/graphics/trading-chest-buy-icon.png",
-				icon_size = 32,
+				icon_size = math.floor(32 * gui_scale),
 				subgroup = "black-market-chests",
 				order = level .. "b",
 				place_result = name_buy,
@@ -363,7 +366,7 @@ local function add_tanks(level)
 				type = "item",
 				name = name_sell,
 				icon = "__BlackMarket2__/graphics/trading-tank-sell-icon.png",
-				icon_size = 32,
+				icon_size = math.floor(32 * gui_scale),
 				subgroup = "black-market-tanks",
 				order = level .. "a",
 				place_result = name_sell,
@@ -398,7 +401,7 @@ local function add_tanks(level)
 				type = "item",
 				name = name_buy,
 				icon = "__BlackMarket2__/graphics/trading-tank-buy-icon.png",
-				icon_size = 32,
+				icon_size = math.floor(32 * gui_scale),
 				subgroup = "black-market-tanks",
 				order = level .. "b",
 				place_result = name_buy,
@@ -480,7 +483,7 @@ local function add_accus(level)
 				type = "item",
 				name = name_sell,
 				icon = "__BlackMarket2__/graphics/trading-accumulator-sell-icon.png",
-				icon_size = 32,
+				icon_size = math.floor(32 * gui_scale),
 				subgroup = "black-market-accumulators",
 				order = level .. "a",
 				place_result = name_sell,
@@ -518,7 +521,7 @@ local function add_accus(level)
 				type = "item",
 				name = name_buy,
 				icon = "__BlackMarket2__/graphics/trading-accumulator-buy-icon.png",
-				icon_size = 32,
+				icon_size = math.floor(32 * gui_scale),
 				subgroup = "black-market-accumulators",
 				order = level .. "b",
 				place_result = name_buy,

--- a/prototypes/signals.lua
+++ b/prototypes/signals.lua
@@ -1,3 +1,6 @@
+-- GUI scale multiplier from mod settings
+local gui_scale = settings.global["BM2-gui_scale"].value
+
 data:extend(
 	{
 		{
@@ -11,7 +14,7 @@ data:extend(
 			type = "virtual-signal",
 			name = "signal-market-auto-all",
 			icon = "__BlackMarket2__/graphics/signal-market-auto-all.png",
-			icon_size = 32,
+			icon_size = math.floor(32 * gui_scale),
 			subgroup = "virtual-signal-market",
 			order = "y[market]-aa"
 		},
@@ -19,7 +22,7 @@ data:extend(
 			type = "virtual-signal",
 			name = "signal-market-auto-sell",
 			icon = "__BlackMarket2__/graphics/signal-market-auto-sell.png",
-			icon_size = 32,
+			icon_size = math.floor(32 * gui_scale),
 			subgroup = "virtual-signal-market",
 			order = "y[market]-ab"
 		},
@@ -27,7 +30,7 @@ data:extend(
 			type = "virtual-signal",
 			name = "signal-market-auto-buy",
 			icon = "__BlackMarket2__/graphics/signal-market-auto-buy.png",
-			icon_size = 32,
+			icon_size = math.floor(32 * gui_scale),
 			subgroup = "virtual-signal-market",
 			order = "y[market]-ac"
 		},

--- a/prototypes/styles.lua
+++ b/prototypes/styles.lua
@@ -1,3 +1,6 @@
+-- GUI scale multiplier from mod settings
+local gui_scale = settings.global["BM2-gui_scale"].value
+
 data:extend(
 	{
 		--------------------------------------------------------------------------------------
@@ -6,14 +9,14 @@ data:extend(
 			name = "font_blkmkt",
 			from = "default",
 			border = false,
-			size = 15
+			size = math.floor(15 * gui_scale)
 		},
 		{
 			type = "font",
 			name = "font_bold_blkmkt",
 			from = "default-bold",
 			border = false,
-			size = 15
+			size = math.floor(15 * gui_scale)
 		},
 		
 		--------------------------------------------------------------------------------------
@@ -21,15 +24,15 @@ data:extend(
 			type = "sprite",
 			name = "sprite_main_blkmkt",
 			filename = "__BlackMarket2__/graphics/but-main.png",
-			width = 30,
-			height = 30,
+			width = math.floor(30 * gui_scale),
+			height = math.floor(30 * gui_scale),
 		},
 		{
 			type = "sprite",
 			name = "sprite_energy_blkmkt",
 			filename = "__BlackMarket2__/graphics/energy.png",
-			width = 32,
-			height = 32,
+			width = math.floor(32 * gui_scale),
+			height = math.floor(32 * gui_scale),
 		},
 	}
 )		
@@ -133,8 +136,8 @@ default_gui.textfield_blkmkt_style =
 	bottom_padding = 0,
 	left_padding = 1,
 	right_padding = 1,
-	minimal_width = 50,
-	maximal_width = 200,
+	minimal_width = math.floor(50 * gui_scale),
+	maximal_width = math.floor(200 * gui_scale),
 	graphical_set =
 	{
 		type = "composition",
@@ -213,7 +216,7 @@ default_gui.button_blkmkt_credits_style =
 	right_padding = 0,
 	bottom_padding = 0,
 	left_padding = 0,
-	height = 36,
+	height = math.floor(36 * gui_scale),
 	scalable = false,
 	left_click_sound =
 	{
@@ -233,8 +236,8 @@ default_gui.sprite_main_blkmkt_style =
 	right_padding = 0,
 	bottom_padding = 0,
 	left_padding = 0,
-	height = 36,
-	width = 36,
+	height = math.floor(36 * gui_scale),
+	width = math.floor(36 * gui_scale),
 	scalable = false,
 }
 
@@ -246,8 +249,8 @@ default_gui.sprite_group_blkmkt_style =
 	right_padding = 0,
 	bottom_padding = 0,
 	left_padding = 0,
-	width = 64,
-	height = 64,
+	width = math.floor(64 * gui_scale),
+	height = math.floor(64 * gui_scale),
 	scalable = false
 }
 
@@ -259,8 +262,8 @@ default_gui.sprite_obj_blkmkt_style =
 	right_padding = 0,
 	bottom_padding = 0,
 	left_padding = 0,
-	height = 32,
-	width = 32,
+	height = math.floor(32 * gui_scale),
+	width = math.floor(32 * gui_scale),
 	-- minimal_width = 32,
 	-- minimal_height = 32,
 	scalable = false

--- a/settings.lua
+++ b/settings.lua
@@ -279,6 +279,16 @@ data:extend({
         default_value = 25,
         order = "fc"
     },
+    -- GUI settings
+    {
+        type = "double-setting",
+        name = "BM2-gui_scale",
+        setting_type = "runtime-global", 
+        minimum_value = 0.5,
+        maximum_value = 3.0,
+        default_value = 1.5,
+        order = "ga"
+    },
     -- other
     {
         type = "int-setting",
@@ -286,13 +296,13 @@ data:extend({
         setting_type = "runtime-global",
         minimum_value = 1,
         default_value = 10,
-        order = "ga"
+        order = "gb"
     },
     {
         type = "bool-setting",
         name = "BM2-unknown_price_reason_logging",
         setting_type = "runtime-global",
         default_value = false,
-        order = "gb"
+        order = "gc"
     }
 })


### PR DESCRIPTION
## Summary
- Add BM2-gui_scale setting (0.5x to 3.0x, default 1.5x)
- Scale all button sizes, fonts, and sprites based on setting
- Scale window dimensions and scroll pane heights
- Scale entity and signal icon sizes
- Improves GUI readability and usability

## Test plan
- [ ] Load the mod and verify GUI elements are scaled correctly
- [ ] Test changing the BM2-gui_scale setting in mod settings
- [ ] Verify all icons and buttons scale appropriately
- [ ] Test different scale values (0.5x, 1.0x, 1.5x, 2.0x, 3.0x)
- [ ] Ensure window dimensions scale correctly

Resolves #36

🤖 Generated with [Claude Code](https://claude.ai/code)