### PR TITLE
fix: exclude Transport Drone recipes from cost calculation

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -897,6 +897,13 @@ local function compute_item_cost(item_name, loops, recipes_used)
 	end
 	recipes_used[#recipes_used+1] = recipe_name
 
+	-- Check if recipe contains drone ingredients
+	for _, ingredient in pairs(recipe.ingredients) do
+		if string.match(ingredient.name:lower(), "drone") then
+			return item_cost_unknown(item_name, "recipe contains drone ingredients")
+		end
+	end
+
 	-- iterate through ingredients and make sure they have a set cost
 	for _, ingredient in pairs(recipe.ingredients) do
 		if storage.prices[ingredient.name] ~= nil then -- do we know the price already?


### PR DESCRIPTION
Add drone ingredient check to prevent astronomical pricing when Transport Drone mod is installed. This resolves the issue where Transport Drone creates recipes using drone + fuel = item, causing BlackMarket2 to calculate extremely high prices.

Fixes #33

Generated with [Claude Code](https://claude.ai/code)