### PR TITLE
Fix GUI scale setting localization missing translations

### DIFF
--- a/locale/cn/cn.cfg
+++ b/locale/cn/cn.cfg
@@ -240,6 +240,7 @@ BM2-tax_growth=税收增长
 BM2-tax_immediate=立即纳税
 BM2-recipe_depth_maximum=定价所需运算配方深度的最大值
 BM2-unknown_price_reason_logging=价格调试
+BM2-gui_scale=GUI缩放
 
 [mod-setting-description]
 BM2-dynamic_prices=如果关闭此选项，则无论您卖出或买入多少，价格都保持不变
@@ -276,5 +277,6 @@ BM2-dynamic_maximal=销售和采购对价格的影响（每项，每天）
 BM2-tax_start=每天一次行动的起始费用（%）
 BM2-tax_growth=频率/天的指数增长：费 = tax_start * (freq ^ tax_growth)
 BM2-tax_immediate=% 立即行动费用
-BM2-recipe_depth_maximum=查找配方的最大“深度”
+BM2-recipe_depth_maximum=查找配方的最大"深度"
 BM2-unknown_price_reason_logging=写入定价为未知的项目的日志，以及原因
+BM2-gui_scale=黑市GUI界面的缩放比例 (0.5-3.0，需要重启)

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -241,6 +241,7 @@ BM2-tax_growth=Tax growth
 BM2-tax_immediate=Tax immediate
 BM2-recipe_depth_maximum=Recipe depth maximum
 BM2-unknown_price_reason_logging=Price Debugging
+BM2-gui_scale=GUI Scale
 
 [mod-setting-description]
 BM2-dynamic_prices=If this is turned off then the prices remain the same no matter how much you sell or buy
@@ -279,3 +280,4 @@ BM2-tax_growth=Exponential growth with frequency/day : fee = tax_start * (freq ^
 BM2-tax_immediate=% Fee for immediate action
 BM2-recipe_depth_maximum=Recipe the maximum 'depth' that BM2 will look into for a recipe, to find its cost.
 BM2-unknown_price_reason_logging=Writes a log of items that are priced as unknown, and the reason for such
+BM2-gui_scale=Scale of the Black Market GUI interface (0.5-3.0, requires restart)


### PR DESCRIPTION
Add missing localization entries for BM2-gui_scale setting in both English and Chinese:
- English: 'GUI Scale' name and description
- Chinese: 'GUI缩放' name and description

Fixes mod-setting-name.BM2-gui_scale unknown key bug reported in issue #92

Generated with [Claude Code](https://claude.ai/code)