### PR TITLE
feat: Add circuit network integration for automated trading

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -55,6 +55,10 @@ local trader_signals =
 	auto_all = { type = "virtual", name = "signal-market-auto-all" },
 	auto_sell = { type = "virtual", name = "signal-market-auto-sell" },
 	auto_buy = { type = "virtual", name = "signal-market-auto-buy" },
+	price = { type = "virtual", name = "signal-market-price" },
+	last_trade = { type = "virtual", name = "signal-market-last-trade" },
+	min_price = { type = "virtual", name = "signal-market-min-price" },
+	max_price = { type = "virtual", name = "signal-market-max-price" },
 }
 
 --------------------------------------------------------------------------------------
@@ -2137,10 +2141,81 @@ local function listen_trader(trader)
 	else
 		listen_signal(trader_signals.auto_buy)
 	end
+	
+	-- Listen for price threshold signals
+	local min_price_val = network.get_signal(trader_signals.min_price)
+	if min_price_val ~= 0 then
+		trader.min_price = min_price_val
+	end
+	
+	local max_price_val = network.get_signal(trader_signals.max_price)
+	if max_price_val ~= 0 then
+		trader.max_price = max_price_val
+	end
 
 	if trader.editer and changed then update_menu_trader(trader.editer, nil, false) end
 
 	return (true)
+end
+
+--------------------------------------------------------------------------------------
+local function output_trader_info(trader)
+	local ent = trader.entity
+	if ent == nil or not ent.valid then return false end
+	
+	local control_behavior = ent.get_control_behavior()
+	if control_behavior == nil then return false end
+	
+	local signals = {}
+	local signal_count = 0
+	
+	-- Output current price of the traded item
+	if trader.item_name and storage.prices then
+		local price_data = storage.prices[trader.item_name]
+		if price_data then
+			signal_count = signal_count + 1
+			signals[signal_count] = {
+				index = signal_count,
+				signal = trader_signals.price,
+				count = math.floor(price_data.current or 0)
+			}
+		end
+	end
+	
+	-- Output time since last trade (in minutes)
+	if trader.hour_period then
+		local hours_since_trade = storage.hour - trader.hour_period
+		signal_count = signal_count + 1
+		signals[signal_count] = {
+			index = signal_count,
+			signal = trader_signals.last_trade,
+			count = hours_since_trade * 60 -- Convert to minutes
+		}
+	end
+	
+	-- Set the circuit network parameters
+	if signal_count > 0 then
+		control_behavior.parameters = signals
+	else
+		control_behavior.parameters = {}
+	end
+	
+	return true
+end
+
+--------------------------------------------------------------------------------------
+local function output_traders_info(force_mem)
+	if storage.prices_computed then return nil end
+	
+	for i = 1, #force_mem.traders_buy do
+		local trader = force_mem.traders_buy[i]
+		output_trader_info(trader)
+	end
+	
+	for i = 1, #force_mem.traders_sell do
+		local trader = force_mem.traders_sell[i]
+		output_trader_info(trader)
+	end
 end
 
 --------------------------------------------------------------------------------------
@@ -2927,6 +3002,7 @@ local function on_tick(event)
 		for name, force in pairs(game.forces) do
 			local force_mem = storage.force_mem[name]
 			listen_traders(force_mem)
+			output_traders_info(force_mem)
 		end
 
 		-- EVERY HOUR :
@@ -2947,14 +3023,25 @@ local function on_tick(event)
 					if storage.hour % trader.period == 0 then
 						trader.hour_period = storage.hour
 						if trader.auto and not force_mem.pause then
-							-- if not(trader.daylight and trader.type == trader_type.energy and trader.entity.surface.darkness > 0.5) then
-							local money1 = sell_trader(trader, force_mem)
-							if money1 == nil then
-								table.remove(force_mem.traders_sell, i)
-							else
-								money = money + money1
+							-- Check price thresholds before selling
+							local should_trade = true
+							if trader.item_name and storage.prices and trader.min_price then
+								local price_data = storage.prices[trader.item_name]
+								if price_data and price_data.current < trader.min_price then
+									should_trade = false
+								end
 							end
-							-- end
+							
+							if should_trade then
+								-- if not(trader.daylight and trader.type == trader_type.energy and trader.entity.surface.darkness > 0.5) then
+								local money1 = sell_trader(trader, force_mem)
+								if money1 == nil then
+									table.remove(force_mem.traders_sell, i)
+								else
+									money = money + money1
+								end
+								-- end
+							end
 						end
 					end
 				end
@@ -2977,11 +3064,22 @@ local function on_tick(event)
 					if storage.hour % trader.period == 0 then
 						trader.hour_period = storage.hour
 						if trader.auto and not force_mem.pause then
-							local money1 = buy_trader(trader, force_mem)
-							if money1 == nil then
-								table.remove(force_mem.traders_buy, i)
-							else
-								money = money + money1
+							-- Check price thresholds before buying
+							local should_trade = true
+							if trader.item_name and storage.prices and trader.max_price then
+								local price_data = storage.prices[trader.item_name]
+								if price_data and price_data.current > trader.max_price then
+									should_trade = false
+								end
+							end
+							
+							if should_trade then
+								local money1 = buy_trader(trader, force_mem)
+								if money1 == nil then
+									table.remove(force_mem.traders_buy, i)
+								else
+									money = money + money1
+								end
 							end
 						end
 					end

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -240,6 +240,11 @@ local function add_chests(level)
 			height = 34,
 			shift = {0.1875, 0}
 		}
+	
+	-- Add circuit network connectivity
+	chest_sell.circuit_wire_connection_point = circuit_connector_definitions["chest"].points
+	chest_sell.circuit_connector_sprites = circuit_connector_definitions["chest"].sprites
+	chest_sell.circuit_wire_max_distance = default_circuit_wire_max_distance
 
 	
 	data:extend(
@@ -281,6 +286,11 @@ local function add_chests(level)
 			height = 34,
 			shift = {0.1875, 0}
 		}
+	
+	-- Add circuit network connectivity
+	chest_buy.circuit_wire_connection_point = circuit_connector_definitions["chest"].points
+	chest_buy.circuit_connector_sprites = circuit_connector_definitions["chest"].sprites
+	chest_buy.circuit_wire_max_distance = default_circuit_wire_max_distance
 
 	data:extend(
 		{
@@ -354,6 +364,11 @@ local function add_tanks(level)
 	tank_sell.pictures.picture.sheets[1].filename = "__BlackMarket2__/graphics/trading-tank-sell.png"
 	tank_sell.pictures.picture.sheets[1].height = 216
 	tank_sell.fluid_box.volume = tank_max
+	
+	-- Add circuit network connectivity
+	tank_sell.circuit_wire_connection_point = circuit_connector_definitions["storage_tank"].points
+	tank_sell.circuit_connector_sprites = circuit_connector_definitions["storage_tank"].sprites
+	tank_sell.circuit_wire_max_distance = default_circuit_wire_max_distance
 
 	data:extend(
 		{
@@ -389,6 +404,11 @@ local function add_tanks(level)
 	tank_buy.pictures.picture.sheets[1].filename = "__BlackMarket2__/graphics/trading-tank-buy.png"
 	tank_buy.pictures.picture.sheets[1].height = 216
 	tank_buy.fluid_box.volume = tank_max
+	
+	-- Add circuit network connectivity
+	tank_buy.circuit_wire_connection_point = circuit_connector_definitions["storage_tank"].points
+	tank_buy.circuit_connector_sprites = circuit_connector_definitions["storage_tank"].sprites
+	tank_buy.circuit_wire_max_distance = default_circuit_wire_max_distance
 
 	data:extend(
 		{

--- a/prototypes/signals.lua
+++ b/prototypes/signals.lua
@@ -31,6 +31,42 @@ data:extend(
 			subgroup = "virtual-signal-market",
 			order = "y[market]-ac"
 		},
+		
+		{
+			type = "virtual-signal",
+			name = "signal-market-price",
+			icon = "__base__/graphics/icons/coin.png",
+			icon_size = 64,
+			subgroup = "virtual-signal-market",
+			order = "y[market]-ba"
+		},
+		
+		{
+			type = "virtual-signal",
+			name = "signal-market-last-trade",
+			icon = "__base__/graphics/icons/clock.png",
+			icon_size = 64,
+			subgroup = "virtual-signal-market",
+			order = "y[market]-bb"
+		},
+		
+		{
+			type = "virtual-signal",
+			name = "signal-market-min-price",
+			icon = "__base__/graphics/icons/iron-plate.png",
+			icon_size = 64,
+			subgroup = "virtual-signal-market",
+			order = "y[market]-ca"
+		},
+		
+		{
+			type = "virtual-signal",
+			name = "signal-market-max-price",
+			icon = "__base__/graphics/icons/uranium-235.png",
+			icon_size = 64,
+			subgroup = "virtual-signal-market",
+			order = "y[market]-cb"
+		},
 
 
 	}


### PR DESCRIPTION
Addresses #issue-29

Adds circuit network integration to enable automated trading based on current prices:

- Add circuit network connectivity to trading chests and tanks
- New virtual signals: price, last-trade, min-price, max-price
- Traders output current prices and trade status to circuit networks
- Price threshold controls: sell only if price >= min_price, buy only if price <= max_price
- Enables reading item prices from logic elements as requested

🤖 Generated with [Claude Code](https://claude.ai/code)