### PR TITLE
Fix multiplayer neutral chest bug (#22)

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -2594,12 +2594,17 @@ local function on_creation(event)
 	end
 
 	if sell_or_buy ~= nil then
+		-- Fix for neutral chest bug (issue #22): ensure trader entities are bound to player's force
+		if event.player_index then
+			local player = game.get_player(event.player_index)
+			if player and player.valid then
+				ent.force = player.force
+			end
+		end
+		
 		local suffix = string.sub(ent_name, 16, 19)
 		local level = suffix_to_level(suffix)
 		local force_mem = storage.force_mem[ent.force.name]
-		-- if ent.force.name = 'neutral' then force_mem = storage.force_mem['player'] end
-		-- this is how you would fix the neutral chest bug, see issue 22, however i cant find
-		-- that setting to test it so im not exactly sure whats up
 		local trader = { entity = ent, sell_or_buy = sell_or_buy, type = type }
 		init_trader(trader, level)
 		trader.n_period = force_mem.n_period


### PR DESCRIPTION
Fixes #22

Ensures trader entities (chests, tanks, accumulators) are assigned to the player's force when built, preventing them from becoming neutral faction entities that cause items to disappear and money to be lost.

This implements the community-suggested fix from moullcz by adding force assignment logic in the on_creation event handler for all trader entity types.

Generated with [Claude Code](https://claude.ai/code)